### PR TITLE
Fix arc definition issue

### DIFF
--- a/Light-Untar.podspec
+++ b/Light-Untar.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/mhausherr/Light-Untar-for-iOS.git", :tag => "0.2.2" }
   s.platform     = :ios, '5.0'
   s.source_files = '*.{h,m}'
-  s.requires_arc = true
+  s.requires_arc = false
 end


### PR DESCRIPTION
A crash may occurred when having an incorrect tar file : 

* The library send up a NSError
* But this NSError is in the autorelease block, then it is dealloc in this same block
* The host application may think it can dealloc the NSError, but as the error object is already released, a segmentation fault is raised