### PR TITLE
Added intermediate folders creation

### DIFF
--- a/Light-Untar/NSFileManager+Tar.m
+++ b/Light-Untar/NSFileManager+Tar.m
@@ -255,6 +255,7 @@ static NSString * const kNSFileManagerLightUntarCorruptFileMessage = @"Invalid b
 
 - (void)writeFileDataForObject:(id)object atLocation:(unsigned long long)location withLength:(unsigned long long)length atPath:(NSString *)path
 {
+    [self createDirectoryAtPath:[path stringByDeletingLastPathComponent] withIntermediateDirectories:YES attributes:nil error:nil];
     if ([object isKindOfClass:[NSData class]]) {
         [self createFileAtPath:path contents:[object subdataWithRange:NSMakeRange(location, length)] attributes:nil]; //Write the file on filesystem
     } else if ([object isKindOfClass:[NSFileHandle class]]) {


### PR DESCRIPTION
Added intermediate folders creation before file creation because sometime it gets a type file with name "path/effective_filename" as filename, so no file into a inner folder will be extracted correctly